### PR TITLE
Count deduplication with zero bytes saved

### DIFF
--- a/src/main/java/com/github/marschall/stringdedupparser/StringDeduplicationParser.java
+++ b/src/main/java/com/github/marschall/stringdedupparser/StringDeduplicationParser.java
@@ -44,7 +44,7 @@ public final class StringDeduplicationParser {
     private int count;
 
     void add(long l) {
-      if (l > 0L) {
+      if (l >= 0L) {
         saved += l;
         count += 1;
       }

--- a/src/test/java/com/github/marschall/stringdedupparser/StringDeduplicationParserTest.java
+++ b/src/test/java/com/github/marschall/stringdedupparser/StringDeduplicationParserTest.java
@@ -40,6 +40,16 @@ public class StringDeduplicationParserTest {
   }
 
   @Test
+  public void parseZeroDeduplicationLog() throws IOException {
+    Path path = Paths.get("src", "test", "resources", "with-zero-deduplication.log");
+    ParseResult result = this.parser.parse(path, StandardCharsets.US_ASCII);
+
+    assertNotNull(result);
+    assertEquals(3L, result.getCount());
+    assertEquals(92160L, result.getSaved());
+  }
+
+  @Test
   public void subSequenceBetween() {
     assertEquals("20.5K", StringDeduplicationParser.subSequenceBetween("116.9K->96.4K(20.5K), avg 17.5%, 0.0018690 secs", '(', ')'));
     assertEquals("", StringDeduplicationParser.subSequenceBetween("116.9K->96.4K(), avg 17.5%, 0.0018690 secs", '(', ')'));
@@ -59,5 +69,4 @@ public class StringDeduplicationParserTest {
     assertEquals(4808, StringDeduplicationParser.parseMemory("4808.0B"));
     assertEquals(11 * 1024 * 1024, StringDeduplicationParser.parseMemory("11.0M"));
   }
-
 }

--- a/src/test/resources/with-zero-deduplication.log
+++ b/src/test/resources/with-zero-deduplication.log
@@ -1,0 +1,3 @@
+2017-01-09T05:30:06.000+0100: 3.042: [GC concurrent-string-deduplication, 142.7K->73.7K(69.0K), avg 48.4%, 0.0016969 secs]
+2017-01-09T05:30:07.000+0100: 4.042: [GC concurrent-string-deduplication, 117.0K->117.0K(0.0B), avg 0.0%, 0.0011717 secs]
+2017-01-09T05:30:08.000+0100: 5.042: [GC concurrent-string-deduplication, 216.9K->195.9K(21.0K), avg 9.7%, 0.0012121 secs]


### PR DESCRIPTION
There are deduplication events that do not save memory. Since these events do also
take time, they should be counted.